### PR TITLE
[adhoc] Changes on apache toree to get to a dist'ble image on Spark 1.6.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ IS_SNAPSHOT?=true
 SNAPSHOT:=-SNAPSHOT
 endif
 
-APACHE_SPARK_VERSION?=1.6.1
+APACHE_SPARK_VERSION?=1.6.2
 IMAGE?=jupyter/pyspark-notebook:8dfd60b729bf
 EXAMPLE_IMAGE?=apache/toree-examples
 GPG?=/usr/local/bin/gpg

--- a/protocol/build.sbt
+++ b/protocol/build.sbt
@@ -30,5 +30,10 @@ libraryDependencies ++= Seq(
 //
 libraryDependencies ++= Seq(
   "org.scalactic" %% "scalactic" % "2.2.6" % "test", // Apache v2
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4" // Apache v2
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4", // Apache v2
+  "com.fasterxml.jackson.module" % "jackson-module-scala_2.10" % "2.7.4"
+)
+
+dependencyOverrides ++= Set(
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4"
 )

--- a/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/SparkKernelInfo.scala
+++ b/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/SparkKernelInfo.scala
@@ -43,7 +43,7 @@ object SparkKernelInfo {
   /**
    * Represents the displayed name of the kernel.
    */
-  val banner                  = "IBM Spark Kernel"
+  val banner                  = "Spark Kernel"
 
   /**
    * Represents the name of the user who started the kernel process.

--- a/scala-interpreter/build.sbt
+++ b/scala-interpreter/build.sbt
@@ -14,3 +14,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License
  */
+dependencyOverrides ++= Set(
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.4.4"
+)

--- a/scala-interpreter/build.sbt
+++ b/scala-interpreter/build.sbt
@@ -14,6 +14,3 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License
  */
-dependencyOverrides ++= Set(
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.4.4"
-)


### PR DESCRIPTION
The following commit includes the needed changes for getting apache toree onto a local tetration branch.

The changes also include the jackson sbt changes to overcome 

"java.lang.VerifyError: class com.fasterxml.jackson.module.scala.ser.ScalaIteratorSerializer" error which is a known issue with tools that use spark. The issue is @ https://github.com/json4s/json4s/issues/320 but found that the bug fix is not complete, the fix in this CL however works.

Reviewers: @sunigup2
